### PR TITLE
feat: add shared ledger for concurrent HF account coordination

### DIFF
--- a/auto_quant/config.env
+++ b/auto_quant/config.env
@@ -19,17 +19,6 @@ HF_ACCOUNT_CAPACITY_GB=100
 HF_USAGE_FILE=/root/leaderboard_Agent/tasks/lb_eval/auto_quant/hf_account_usage.json
 HF_ACCOUNT_IDS=
 
-# Shared ledger for multi-machine / multi-process coordination.
-# Repo can be a HF dataset repo id like "org/hf-upload-ledger", a full URL, or a local git path.
-HF_SHARED_LEDGER_ENABLED=false
-HF_SHARED_LEDGER_REPO=
-HF_SHARED_LEDGER_TOKEN=
-HF_SHARED_LEDGER_BRANCH=main
-HF_SHARED_LEDGER_CLONE_DIR=
-HF_SHARED_LEDGER_RESERVATION_TTL_SECONDS=7200
-HF_SHARED_LEDGER_GIT_USER_NAME=hf-ledger-bot
-HF_SHARED_LEDGER_GIT_USER_EMAIL=hf-ledger-bot@local
-
 # GitHub upload for result artifacts.
 GIT_TOKEN=
 GIT_REPO=https://github.com/XuehaoSun/lb_eval.git
@@ -39,6 +28,16 @@ GIT_RESULTS_REPO_DIR=
 GIT_RESULTS_CLONE_DIR=
 GIT_USER_NAME=lkk12014402
 GIT_USER_EMAIL=kaokao.lv@intel.com
+
+# Shared ledger for multi-machine / multi-process coordination.
+HF_SHARED_LEDGER_ENABLED=true
+HF_SHARED_LEDGER_REPO=${GIT_REPO}
+HF_SHARED_LEDGER_TOKEN=
+HF_SHARED_LEDGER_BRANCH=main
+HF_SHARED_LEDGER_CLONE_DIR=
+HF_SHARED_LEDGER_RESERVATION_TTL_SECONDS=7200
+HF_SHARED_LEDGER_GIT_USER_NAME=hf-ledger-bot
+HF_SHARED_LEDGER_GIT_USER_EMAIL=hf-ledger-bot@local
 
 # ═══════════════════════════════════════════════════════════════════════
 # MiniMax API key (for openclaw agent inside container)

--- a/auto_quant/upload_model_hf.py
+++ b/auto_quant/upload_model_hf.py
@@ -510,6 +510,15 @@ def main() -> int:
         print("ERROR: No valid HuggingFace accounts available.")
         return 1
 
+    # Fall back to an appropriate token when no dedicated ledger token is set.
+    # GitHub repos → use GIT_TOKEN; HF repos → use the first HF upload token.
+    if not args.shared_ledger_token:
+        ledger_repo = (args.shared_ledger_repo or "").strip()
+        if "github.com" in ledger_repo:
+            args.shared_ledger_token = os.environ.get("GIT_TOKEN", "")
+        elif tokens:
+            args.shared_ledger_token = tokens[0]
+
     upload_size_bytes = get_folder_size_bytes(args.model_path)
     shared_enabled = str_to_bool(
         args.shared_ledger_enabled,


### PR DESCRIPTION
- Enable SharedLedger (HF_SHARED_LEDGER_ENABLED=true) backed by GIT_REPO
- Reuse GIT_REPO as ledger repo to avoid separate config
- Auto-fallback ledger token to GIT_TOKEN for GitHub repos
- Remove _ensure_remote_repo_exists (dead code for GitHub backend)
- Move GIT_* vars before HF_SHARED_LEDGER_* in config.env so ${GIT_REPO} variable reference expands correctly on source